### PR TITLE
fix: filedescriptor leaks

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -67,6 +67,7 @@ def bypass_cloudflare(url: str, retries: int) -> ChromiumPage:
         return page
     except Exception as e:
         page.listen.stop()
+        page.close()
         page.quit()
         raise e
 
@@ -115,6 +116,7 @@ async def get_solverr(request: ClientRequest):
         if page:
             try:
                 logger.debug("Quitting ChromiumPage", extra={'requestUrl': request.url})
+                page.close()
                 page.quit()
             except Exception as e:
                 logger.error("An error occured while quit page with error: %s", str(e), stack_info=True, extra={'requestUrl': request.url})


### PR DESCRIPTION
**Problem Description:**

When running this application in Docker for an extended period of time (typically between 1 to 3 weeks) without a restart, the application eventually crashes due to a "too many open files" error. In my environment, the file descriptor limit is 1,048,576 (`ulimit -n` output).

Although the application handles a large number of requests, it does not process millions of concurrent requests. This strongly suggests that there is a file descriptor (FD) leak. It’s likely that some file descriptors are not properly closed when exceptions are raised.

**Proposed Fix:**

This PR ensures that all file descriptors are correctly closed even in the event of an exception. This should prevent the FD exhaustion over time.

**Stack trace:**

```
172.18.0.9:52484 - "POST /v1 HTTP/1.1" 500 | timestamp=2025-06-02T21:41:48.123133+00:00

Trying to solve | request=cmd='request.get' cookies=None maxTimeout=60000 url='*****************' postData=None timestamp=2025-06-02T21:41:52.331266+00:00

An error occured while solving with error: filedescriptor out of range in select() | stack_info=Stack (most recent call last):
  File "/app/src/server.py", line 143, in <module>
    uvicorn.run(app, host="0.0.0.0", port=int(args.port), log_config=None)
  File "/app/.venv/lib/python3.13/site-packages/uvicorn/main.py", line 579, in run
    server.run()
  File "/app/.venv/lib/python3.13/site-packages/uvicorn/server.py", line 66, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/usr/local/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
  File "/usr/local/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 712, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 683, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 2040, in _run_once
    handle._run()
  File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/app/.venv/lib/python3.13/site-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/app/.venv/lib/python3.13/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
  File "/app/.venv/lib/python3.13/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/app/.venv/lib/python3.13/site-packages/starlette/applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/app/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/app/.venv/lib/python3.13/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/app/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/app/.venv/lib/python3.13/site-packages/starlette/routing.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/app/.venv/lib/python3.13/site-packages/starlette/routing.py", line 735, in app
    await route.handle(scope, receive, send)
  File "/app/.venv/lib/python3.13/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/app/.venv/lib/python3.13/site-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/app/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/app/.venv/lib/python3.13/site-packages/starlette/routing.py", line 73, in app
    response = await f(request)
  File "/app/.venv/lib/python3.13/site-packages/fastapi/routing.py", line 301, in app
    raw_response = await run_endpoint_function(
  File "/app/.venv/lib/python3.13/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
    return await dependant.call(**values)
  File "/app/src/server.py", line 115, in get_solverr
    logger.error("An error occured while solving with error: %s", str(e), stack_info=True, extra={'requestUrl': request.url}) requestUrl=************** timestamp=2025-06-02T21:41:52.342883+00:00
```
